### PR TITLE
feat: Header をレイアウトに移動し、スクロール固定化

### DIFF
--- a/client/app/home/page.tsx
+++ b/client/app/home/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
-import Header from "@/components/Header";
 import GroupCard from "@/components/GroupCard";
 import CreateGroupCard from "@/components/CreateGroupCard";
 import { getMyRooms } from "@/lib/rooms";
@@ -38,10 +37,7 @@ export default function HomePage() {
   const memoryRooms = rooms.filter((r) => isExpired(r.expires_at));
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg)]">
-      <Header />
-
-      <main className="px-[var(--page-padding)] py-6">
+    <main className="px-[var(--page-padding)] py-6">
         <div className="mx-auto max-w-[var(--max-width-content)]">
           {/* toggle + mode label */}
           <div className="mb-8 flex items-center gap-4">
@@ -94,7 +90,6 @@ export default function HomePage() {
               ))}
           </div>
         </div>
-      </main>
-    </div>
+    </main>
   );
 }

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { AuthProvider } from "@/context/AuthContext";
+import Header from "@/components/Header";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -33,12 +34,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja" className="overscroll-none">
+    <html lang="ja">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased h-screen flex flex-col overflow-hidden`}
       >
         <AuthProvider>
-          {children}
+          <Header />
+          <div className="flex-1 min-h-0 overflow-y-auto overscroll-none bg-background">
+            {children}
+          </div>
         </AuthProvider>
       </body>
     </html>

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
-import Header from "@/components/Header";
 import { signIn } from "@/lib/auth";
 import { useAuth } from "@/context/AuthContext";
 
@@ -32,10 +31,7 @@ export default function Home() {
   };
 
   return (
-    <div className="min-h-screen bg-background">
-      <Header />
-
-      <main className="mx-auto flex min-h-[calc(100vh-88px)] w-full max-w-(--max-width-content) items-center px-(--page-padding) py-8 md:py-12">
+    <main className="mx-auto flex min-h-full w-full max-w-(--max-width-content) items-center px-(--page-padding) py-8 md:py-12">
         <div className="grid w-full grid-cols-1 items-stretch gap-6 lg:grid-cols-[1.15fr_0.85fr] lg:gap-8">
           <section
             className="rounded-(--radius-card) border p-6 shadow-(--shadow-card) sm:p-8"
@@ -212,7 +208,6 @@ export default function Home() {
             </p>
           </section>
         </div>
-      </main>
-    </div>
+    </main>
   );
 }

--- a/client/app/profile/page.tsx
+++ b/client/app/profile/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import { getProfile, updateDisplayName, signOut } from "@/lib/auth";
-import Header from "@/components/Header";
 
 type Notice = { type: "success" | "error"; text: string };
 
@@ -64,10 +63,7 @@ export default function ProfilePage() {
 	if (loading || !user) return null;
 
 	return (
-		<div className="min-h-screen bg-background">
-			<Header />
-
-			<main className="mx-auto w-full max-w-(--max-width-content) px-(--page-padding) py-8 md:py-12">
+		<main className="mx-auto w-full max-w-(--max-width-content) px-(--page-padding) py-8 md:py-12">
 				<section
 					className="mx-auto w-full max-w-xl rounded-(--radius-card) border p-6 shadow-(--shadow-card) sm:p-8"
 					style={{
@@ -138,7 +134,6 @@ export default function ProfilePage() {
 						ログアウト
 					</button>
 				</section>
-			</main>
-		</div>
+		</main>
 	);
 }

--- a/client/app/rooms/[roomId]/dm/[userId]/page.tsx
+++ b/client/app/rooms/[roomId]/dm/[userId]/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
-import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";
 import ChatPanel from "@/components/ChatPanel";
 import { getRoomDetail, getRoomMembers } from "@/lib/rooms";
@@ -36,9 +35,7 @@ export default function DmPage() {
   const chatName = members.find((m) => m.userId === userId)?.displayName ?? "Unknown";
 
   return (
-    <div className="flex h-screen flex-col overflow-hidden bg-[#F6F7F9] text-[#4A5568]">
-      <Header />
-
+    <div className="flex h-full flex-col overflow-hidden bg-[#F6F7F9] text-[#4A5568]">
       <main className="mx-auto flex min-h-0 w-full max-w-[1400px] flex-1 flex-col gap-4 px-3 py-3 md:flex-row md:gap-5 md:px-5 md:py-4">
         <Sidebar
           roomId={roomId}

--- a/client/app/rooms/[roomId]/invite/page.tsx
+++ b/client/app/rooms/[roomId]/invite/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
-import Header from "@/components/Header";
 import QRCode from "react-qr-code";
 import { getRoomDetail } from "@/lib/rooms";
 import { getProfile } from "@/lib/auth";
@@ -45,10 +44,7 @@ export default function InviteQrPage() {
   const inviteUrl = `${origin}/rooms/${roomId}/join/${room.invite_code}`;
 
   return (
-    <div className="flex min-h-screen flex-col bg-[#F6F7F9] text-[#4A5568]">
-      <Header />
-
-      <main className="flex flex-1 items-center justify-center px-4 py-8">
+    <main className="flex min-h-full flex-col items-center justify-center bg-[#F6F7F9] px-4 py-8 text-[#4A5568]">
         <div className="w-full max-w-xl rounded-2xl border border-[#E5E7EB] bg-white p-6 shadow-sm text-center">
 
           <p className="mb-2 text-sm font-bold text-[#7FA9C9]">Invite QR</p>
@@ -77,7 +73,6 @@ export default function InviteQrPage() {
             チャットに戻る
           </button>
         </div>
-      </main>
-    </div>
+    </main>
   );
 }

--- a/client/app/rooms/[roomId]/join/[inviteCode]/page.tsx
+++ b/client/app/rooms/[roomId]/join/[inviteCode]/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
-import Header from "@/components/Header";
 import { getRoomPreview, joinRoom } from "@/lib/rooms";
 import type { RoomPreview } from "@/types";
 
@@ -47,10 +46,7 @@ export default function JoinPage() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col bg-[#F6F7F9] text-[#4A5568]">
-      <Header />
-
-      <main className="flex flex-1 items-center justify-center px-4 py-8">
+    <main className="flex min-h-full flex-col items-center justify-center bg-[#F6F7F9] px-4 py-8 text-[#4A5568]">
         <div className="w-full max-w-md rounded-2xl border border-[#E5E7EB] bg-white p-6 shadow-sm">
 
           {fetchError ? (
@@ -97,7 +93,6 @@ export default function JoinPage() {
           )}
 
         </div>
-      </main>
-    </div>
+    </main>
   );
 }

--- a/client/app/rooms/[roomId]/page.tsx
+++ b/client/app/rooms/[roomId]/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
-import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";
 import ChatPanel from "@/components/ChatPanel";
 import { getRoomDetail, getRoomMembers } from "@/lib/rooms";
@@ -34,9 +33,7 @@ export default function RoomPage() {
   const isMemoryMode = isExpired(room.expires_at);
 
   return (
-    <div className="flex h-screen flex-col overflow-hidden bg-[#F6F7F9] text-[#4A5568]">
-      <Header />
-
+    <div className="flex h-full flex-col overflow-hidden bg-[#F6F7F9] text-[#4A5568]">
       <main className="mx-auto flex min-h-0 w-full max-w-[1400px] flex-1 flex-col gap-4 px-3 py-3 md:flex-row md:gap-5 md:px-5 md:py-4">
         <Sidebar
           roomId={roomId}

--- a/client/app/rooms/new/page.tsx
+++ b/client/app/rooms/new/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import Header from "@/components/Header";
 import { useAuth } from "@/context/AuthContext";
 import { createRoom } from "@/lib/rooms";
 
@@ -126,10 +125,7 @@ export default function NewRoomPage() {
 	if (loading || !user) return null;
 
 	return (
-		<div className="min-h-screen bg-background">
-			<Header />
-
-			<main className="mx-auto w-full max-w-(--max-width-content) px-(--page-padding) py-8 md:py-12">
+		<main className="mx-auto w-full max-w-(--max-width-content) px-(--page-padding) py-8 md:py-12">
 				<section
 					className="mx-auto w-full max-w-2xl rounded-(--radius-card) border p-6 shadow-(--shadow-card) sm:p-8"
 					style={{
@@ -275,7 +271,6 @@ export default function NewRoomPage() {
 						</p>
 					)}
 				</section>
-			</main>
-		</div>
+		</main>
 	);
 }

--- a/client/app/signin/page.tsx
+++ b/client/app/signin/page.tsx
@@ -5,7 +5,6 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/context/AuthContext";
 import { signIn } from "@/lib/auth";
-import Header from "@/components/Header";
 
 function SignInForm() {
   const router = useRouter();
@@ -38,7 +37,7 @@ function SignInForm() {
   const signUpHref = raw ? `/signup?redirect=${encodeURIComponent(raw)}` : "/signup";
 
   return (
-    <div className="flex min-h-[calc(100vh-88px)] items-center justify-center px-4">
+    <div className="flex min-h-full items-center justify-center px-4">
       <div
         className="w-full max-w-md rounded-(--radius-card) border p-8 shadow-(--shadow-card)"
         style={{
@@ -134,11 +133,8 @@ function SignInForm() {
 
 export default function SignInPage() {
   return (
-    <div className="min-h-screen bg-background">
-      <Header />
-      <Suspense>
-        <SignInForm />
-      </Suspense>
-    </div>
+    <Suspense>
+      <SignInForm />
+    </Suspense>
   );
 }

--- a/client/app/signup/page.tsx
+++ b/client/app/signup/page.tsx
@@ -5,7 +5,6 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/context/AuthContext";
 import { signUp } from "@/lib/auth";
-import Header from "@/components/Header";
 
 function SignUpForm() {
   const router = useRouter();
@@ -43,7 +42,7 @@ function SignUpForm() {
   const signInHref = raw ? `/signin?redirect=${encodeURIComponent(raw)}` : "/signin";
 
   return (
-    <div className="flex min-h-[calc(100vh-88px)] items-center justify-center px-4">
+    <div className="flex min-h-full items-center justify-center px-4">
       <div
         className="w-full max-w-md rounded-(--radius-card) border p-8 shadow-(--shadow-card)"
         style={{
@@ -83,12 +82,9 @@ function SignUpForm() {
 
 export default function SignUpPage() {
   return (
-    <div className="min-h-screen bg-background">
-      <Header />
-      <Suspense>
-        <SignUpForm />
-      </Suspense>
-    </div>
+    <Suspense>
+      <SignUpForm />
+    </Suspense>
   );
 }
 

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -22,7 +22,7 @@ export default function Header() {
 
 	return (
 		<header
-			className="w-full"
+			className="w-full shrink-0"
 			style={{
 				height: "56px",
 				backgroundColor: "var(--color-accent-1)",


### PR DESCRIPTION
- app/layout.tsx に Header を追加し、全ページで共通化
- body を h-screen flex flex-col に変更し、Header を固定
- スクロール領域を flex-1 overflow-y-auto overscroll-none の div に集約
- 各ページから <Header /> と外側の min-h-screen ラッパーを削除
- チャットページは h-screen → h-full に変更し内部スクロールを維持
- signin/signup の min-h-[calc(100vh-88px)] → min-h-full に修正